### PR TITLE
Fix permissions model having wrong fillable value

### DIFF
--- a/app/Models/Permission.php
+++ b/app/Models/Permission.php
@@ -10,7 +10,7 @@ class Permission extends Model
     use HasFactory;
 
     protected $fillable = [
-        'name',
+        'title',
     ];
 
     public function roles()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] ♻️ Refactor
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🚩 Other

## Description

I know this is just a demo repository, but still. The fillable value being `name` when it should be `title` did bother me.
So I decided to submit a quick PR for it. 🙂&nbsp; Doesn't change the outcome of the demo since it works even with the wrong value.

But this will fix the `$fillable` for a later end-user who might want to use this as a base and add the ability to create `Permissions` via a form.
